### PR TITLE
House keeping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ uncrustify.cfg export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 m4 export-ignore
+configure.ac export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ Makefile
 build
 systemburn
 *~
+.DS_Store
+\#*


### PR DESCRIPTION
Adds another export ignore to ensure that configure.ac is not caught in the tallball and set .gitignore to ignore Mac database files and emacs recovery files.
